### PR TITLE
Rename Alloc trait to Allocator in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This WG aims to:
 
 * Define traits and other APIs for memory allocators,
-  with the unstable [`std::alloc::Alloc`] trait as a starting point.
+  with the unstable [`std::alloc::Allocator`] trait as a starting point.
 
 * Make collections such as `Vec<T>` able to use any allocator,
   most likely through an additional type parameter.
@@ -22,7 +22,7 @@ For lower-latency discussion, we have the [`t-libs/wg-allocators`] stream on Zul
 To try out different proposals, [Tim](https://github.com/TimDiekmann) has created a crate at [TimDiekmann/alloc-wg](https://github.com/TimDiekmann/alloc-wg). For more information on this consult the [readme](https://github.com/TimDiekmann/alloc-wg/blob/master/README.md).
 
 
-[`std::alloc::Alloc`]: https://doc.rust-lang.org/1.34.0/std/alloc/trait.Alloc.html
+[`std::alloc::Allocator`]: https://doc.rust-lang.org/std/alloc/trait.Allocator.html
 [RFC #1398]: https://github.com/rust-lang/rfcs/pull/1398 "Allocators, take III"
 [tracking issue #32838]: https://github.com/rust-lang/rust/issues/32838 "Allocator traits and std::heap"
 [tracking issue #42774]: https://github.com/rust-lang/rust/issues/42774 "Tracking issue for custom allocators in standard collections"


### PR DESCRIPTION
Looks like the trait got renamed in https://github.com/rust-lang/rust/pull/79286